### PR TITLE
[enhancement] Make Cosmos-Tokenizer pip installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Cosmos Tokenizer delivers 8x more total compression than state-of-the-art (SOTA)
 git clone https://github.com/NVIDIA/Cosmos-Tokenizer.git
 cd Cosmos-Tokenizer
 ```
-- Install dependencies
+- Install via pip
 ```
-pip3 install -r requirements.txt
 apt-get install -y ffmpeg
+pip3 install -e .
 ```
 
 Preferably, build a docker image using the provided Dockerfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ loguru>=0.7.0
 mediapy==1.1.6
 einops==0.7.0
 einx==0.1.3
-huggingface-hub==0.26.2
+huggingface-hub>=0.26.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name="cosmos-tokenizer",
-    version="0.1.0",
+    version="1.0.0",
     author="NVIDIA Corporation",
     description="A suite of image and video neural tokenizers",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Setup for pip package."""
+
+from setuptools import setup, find_packages
+
+# Read requirements
+with open('requirements.txt') as f:
+    requirements = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+
+# Read README for long description
+with open('README.md', 'r', encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name="cosmos-tokenizer",
+    version="0.1.0",
+    author="NVIDIA Corporation",
+    description="A suite of image and video neural tokenizers",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/NVIDIA/Cosmos-Tokenizer",
+    packages=find_packages(),
+    python_requires=">=3.10",
+    install_requires=requirements,
+    exclude=["assets", "test_data"],
+    entry_points={
+        'console_scripts': [
+            'cosmos-image=cosmos_tokenizer.image_cli:main',
+            'cosmos-video=cosmos_tokenizer.video_cli:main',
+        ],
+    },
+)


### PR DESCRIPTION
This PR makes the Cosmos-Tokenizer pip installable. And users can directly call `python3 -m cosmos_tokenizer.image_cli` and `python3 -m cosmos_tokenizer.video_cli` anywhere after the installation since we added the following to `setup.py`
```python
    entry_points={
        'console_scripts': [
            'cosmos-image=cosmos_tokenizer.image_cli:main',
            'cosmos-video=cosmos_tokenizer.video_cli:main',
        ],
    },
```