### PR TITLE
Fix load_jit_model utility to consider device variable

### DIFF
--- a/cosmos_tokenizer/utils.py
+++ b/cosmos_tokenizer/utils.py
@@ -121,7 +121,7 @@ def load_jit_model(
     Returns:
         The JIT compiled model loaded to device and on eval mode.
     """
-    model = torch.jit.load(jit_filepath)
+    model = torch.jit.load(jit_filepath, device)
     return model.eval().to(device)
 
 


### PR DESCRIPTION
I was trying to use CPU to encode and decode images however, I realized that device variable is not passed to **torch.jit.load** in **load_jit_model**. Although its really slow on CPU (it took 1 hour to encode and decode the test image using 12th Gen Intel® Core™ i7-1255U), not everyone has access to GPU and CPU is useful specifically for images and experiments for students like me.
I would like to contribute to this repository or other COSMOS repositories. Thanks for making these fantastic models and data open source.